### PR TITLE
Lista de candidatos em ordem aleatória

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "API pública para consulta dos dados coletados pelo projeto Laddres",
   "main": "index.js",
   "scripts": {

--- a/src/candidatos/por-cargo.js
+++ b/src/candidatos/por-cargo.js
@@ -14,7 +14,9 @@ const sql = (idCargo, idEstado) => `
     hot_dados_candidato
   WHERE
     id_cargo = ${idCargo} AND
-    (id_estado_candidatura = ${idEstado} OR id_estado_candidatura IS NULL);`
+    (id_estado_candidatura = ${idEstado} OR id_estado_candidatura IS NULL)
+  ORDER BY
+    RAND();`
 
 const formatarRetorno = candidatos => (
   candidatos.map(candidato => ({


### PR DESCRIPTION
Agora, quando o usuário requisitar a lista de candidatos, a receberá em ordem aletória, ao invés de receber por ordem de idCandidato